### PR TITLE
89 scramble method update_並び替えメソッドの修正＋FE正式名称の表示修正

### DIFF
--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -323,7 +323,7 @@ export default function ResultPage() {
           )}
         </div>
       </div>
-      <QuestionList questions={questionList} incorrectWord={incorrectWordData} />
+      <QuestionList questions={questionList} incorrectWord={incorrectWordData} mode={mode} />
     </div>
   );
 }

--- a/components/game/QuestionList.tsx
+++ b/components/game/QuestionList.tsx
@@ -4,9 +4,10 @@ import { GameWord } from '@/types/word';
 type QuestionListProps = {
   questions: GameWord[];
   incorrectWord?: { word: string; userAnswer: string; category?: string; hint?: string; fullName?: string; fullNameJa?: string } | null;
+  mode?: string; // モード情報を直接渡す
 }
 
-export const QuestionList = ({ questions, incorrectWord }: QuestionListProps) => {
+export const QuestionList = ({ questions, incorrectWord, mode }: QuestionListProps) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const toggleVisibility = () => {
@@ -61,7 +62,7 @@ export const QuestionList = ({ questions, incorrectWord }: QuestionListProps) =>
                     fullNameJa: incorrectWord.fullNameJa,
                     isCorrect: false,
                     userAnswer: incorrectWord.userAnswer,
-                    mode: questions[0]?.mode || 'html-css', // フォールバック
+                    mode: mode || questions[0]?.mode || 'fe', // 渡されたmodeを優先
                     scrambled: '' // 不要だが型のため
                   }] : [])
                 ];

--- a/contexts/GameStateContext.tsx
+++ b/contexts/GameStateContext.tsx
@@ -2,9 +2,10 @@
 
 import React, { createContext, useContext, useState, useEffect, useMemo, ReactNode } from 'react'
 import { GameWord, GameMode } from '@/types/word'
-import { htmlCssTerms } from '@/data/htmlCssTerms'
-import { rubyMethods } from '@/data/rubyMethods'
-import { feTerms } from '@/data/feTerms'
+import { getRandomHtmlCssTerm, htmlCssTerms } from '@/data/htmlCssTerms'
+import { getRandomRubyMethod, rubyMethods } from '@/data/rubyMethods'
+import { getRandomFeTerm, feTerms } from '@/data/feTerms'
+import { scrambleWord } from '@/utils/scrambleWord'
 
 interface GameStateContextType {
   // Game state
@@ -15,12 +16,12 @@ interface GameStateContextType {
   currentRound: number
   totalWordsCount: number
   questionList: GameWord[]
-  
+
   // Game status
   isAnswered: boolean
   isCorrect: boolean | null
   showIncompleteWarning: boolean
-  
+
   // Actions
   setCurrentWord: React.Dispatch<React.SetStateAction<GameWord | null>>
   setQuestionCount: React.Dispatch<React.SetStateAction<number>>
@@ -31,7 +32,7 @@ interface GameStateContextType {
   setIsAnswered: React.Dispatch<React.SetStateAction<boolean>>
   setIsCorrect: React.Dispatch<React.SetStateAction<boolean | null>>
   setShowIncompleteWarning: React.Dispatch<React.SetStateAction<boolean>>
-  
+
   // Game logic
   getRandomWord: () => GameWord
   handleNextQuestion: () => void
@@ -53,7 +54,7 @@ export const GameStateProvider = ({ children, mode }: GameStateProviderProps) =>
   const [currentRound, setCurrentRound] = useState(1)
   const [totalWordsCount, setTotalWordsCount] = useState(0)
   const [questionList, setQuestionList] = useState<GameWord[]>([])
-  
+
   // Game status
   const [isAnswered, setIsAnswered] = useState(false)
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null)
@@ -75,31 +76,32 @@ export const GameStateProvider = ({ children, mode }: GameStateProviderProps) =>
   }
 
   const getRandomWord = (): GameWord => {
-    const allWords = getAllWords(mode)
-    const availableWords = allWords.filter(word => !usedWordIds.has(word.id))
+    // 全問題と未出題問題を取得
+    const allWords = getAllWords(mode);
+    const availableWords = allWords.filter(word => !usedWordIds.has(word.id));
 
-    // 全問題を出題済みの場合、次のラウンドを開始
+    // 全問題出題済みの場合、2周目に進む
     if (availableWords.length === 0) {
-      const nextRound = currentRound + 1
-      setCurrentRound(nextRound)
-      setUsedWordIds(new Set())
-
-      // 全問題から再びランダム選択
-      const randomIndex = Math.floor(Math.random() * allWords.length)
-      const selectedWord = allWords[randomIndex]
+      const nextRound = currentRound + 1;
+      setCurrentRound(nextRound);
+      setUsedWordIds(new Set());
+      
+      // 全問題から再びランダム選択（2周目開始）
+      const randomIndex = Math.floor(Math.random() * allWords.length);
+      const selectedWord = allWords[randomIndex];
       return {
         ...selectedWord,
-        scrambled: selectedWord.original.split('').sort(() => Math.random() - 0.5).join('')
-      }
+        scrambled: scrambleWord(selectedWord.original)
+      };
     }
 
-    // 未出題の問題からランダム選択
-    const randomIndex = Math.floor(Math.random() * availableWords.length)
-    const selectedWord = availableWords[randomIndex]
+    // 未出題問題からランダム選択
+    const randomIndex = Math.floor(Math.random() * availableWords.length);
+    const selectedWord = availableWords[randomIndex];
     return {
       ...selectedWord,
-      scrambled: selectedWord.original.split('').sort(() => Math.random() - 0.5).join('')
-    }
+      scrambled: scrambleWord(selectedWord.original)
+    };
   }
 
   const handleNextQuestion = () => {
@@ -159,7 +161,7 @@ export const GameStateProvider = ({ children, mode }: GameStateProviderProps) =>
     isAnswered,
     isCorrect,
     showIncompleteWarning,
-    
+
     // Actions
     setCurrentWord,
     setQuestionCount,
@@ -170,7 +172,7 @@ export const GameStateProvider = ({ children, mode }: GameStateProviderProps) =>
     setIsAnswered,
     setIsCorrect,
     setShowIncompleteWarning,
-    
+
     // Game logic
     getRandomWord,
     handleNextQuestion,

--- a/data/feTerms.ts
+++ b/data/feTerms.ts
@@ -1,24 +1,5 @@
 import { Word, GameWord } from '@/types/word'
-// import { scrambleWord } from '@/utils/scrambleLogic'
-
-const scrambleWord = (word: string): string => {
-  const letters = word.split('');
-
-  // Fisher-Yates shuffle algorithm
-  for (let i = letters.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [letters[i], letters[j]] = [letters[j], letters[i]];
-  }
-
-  const scrambled = letters.join('');
-
-  // 元の単語と同じになった場合は再シャッフル
-  if (scrambled === word && word.length > 2) {
-    return scrambleWord(word);
-  }
-
-  return scrambled;
-};
+import { scrambleWord } from '@/utils/scrambleWord'
 
 // 基本情報技術者試験用語データベース（合計 100語）
 // 3文字: 66語, 4文字: 27語, 5文字: 6語, 7文字: 1語

--- a/data/htmlCssTerms.ts
+++ b/data/htmlCssTerms.ts
@@ -1,4 +1,5 @@
 import { GameWord, Word } from '@/types/word';
+import { scrambleWord } from '@/utils/scrambleWord';
 
 /**
  * HTML/CSS terms database for the scramble game
@@ -9,32 +10,6 @@ import { GameWord, Word } from '@/types/word';
  * - 複数コンポーネントから参照可能
  * - 問題の追加・修正が容易
  */
-
-/**
- * 単語をランダムにシャッフルする関数
- * なぜこの関数が必要？
- * - 毎回異なる並び順で再プレイ性向上
- * - 手動でscrambledを考える手間を削減
- * - 統一的なアルゴリズムで一貫性確保
- */
-const scrambleWord = (word: string): string => {
-  const letters = word.split('');
-
-  // Fisher-Yates shuffle algorithm
-  for (let i = letters.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [letters[i], letters[j]] = [letters[j], letters[i]];
-  }
-
-  const scrambled = letters.join('');
-
-  // 元の単語と同じになった場合は再シャッフル
-  if (scrambled === word && word.length > 2) {
-    return scrambleWord(word);
-  }
-
-  return scrambled;
-};
 
 export const htmlCssTerms: Word[] = [
   // HTML Elements (42語) - 既存29語 + 新規13語

--- a/data/rubyMethods.ts
+++ b/data/rubyMethods.ts
@@ -1,26 +1,5 @@
 import { GameWord, Word } from '@/types/word';
-
-/**
- * 単語をランダムにシャッフルする関数
- */
-const scrambleWord = (word: string): string => {
-  const letters = word.split('');
-
-  // Fisher-Yates shuffle algorithm
-  for (let i = letters.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [letters[i], letters[j]] = [letters[j], letters[i]];
-  }
-
-  const scrambled = letters.join('');
-
-  // 元の単語と同じになった場合は再シャッフル
-  if (scrambled === word && word.length > 2) {
-    return scrambleWord(word);
-  }
-
-  return scrambled;
-};
+import { scrambleWord } from '@/utils/scrambleWord';
 
 /**
  * Ruby methods and concepts for the scramble game

--- a/utils/scrambleWord.ts
+++ b/utils/scrambleWord.ts
@@ -1,0 +1,38 @@
+/**
+ * 単語をランダムにシャッフルする共通ユーティリティ関数
+ * 元の単語と同じ並びになった場合は再シャッフルを行う
+ */
+export const scrambleWord = (word: string): string => {
+  // 2文字以下の場合は元の単語をそのまま返す（シャッフルの意味がない）
+  if (word.length <= 2) {
+    return word;
+  }
+
+  let scrambled: string;
+  let attempts = 0;
+  const maxAttempts = 20; // 無限ループ防止
+
+  do {
+    const letters = word.split('');
+
+    // Fisher-Yates shuffle algorithm
+    for (let i = letters.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [letters[i], letters[j]] = [letters[j], letters[i]];
+    }
+
+    scrambled = letters.join('');
+    attempts++;
+
+    // 最大試行回数に達した場合、強制的に異なる並びを作成
+    if (attempts >= maxAttempts && scrambled === word) {
+      // 最初の2文字を入れ替える
+      const letters = word.split('');
+      [letters[0], letters[1]] = [letters[1], letters[0]];
+      scrambled = letters.join('');
+      break;
+    }
+  } while (scrambled === word && attempts < maxAttempts);
+
+  return scrambled;
+};


### PR DESCRIPTION
並び替えのメソッドが正しく動作せず、元の単語と同じ並びで出題されるバグを修正。
別の場所でも並び替えのメソッドが記載されていてそのメソッドのランダム率が低かった。
併せて、並び替えメソッドの定義を共通化して、各ファイルで参照するように修正。

FEモードで結果ページにて、回答数０の場合に正式名称が表示されていないバグを修正。